### PR TITLE
detect imported Xerxes 1.x proxy URLs and display them as direct URLs

### DIFF
--- a/application/src/Xerxes/Record/Link.php
+++ b/application/src/Xerxes/Record/Link.php
@@ -273,6 +273,12 @@ class Link
 		
 		$xml->url = $this->getURL();
 		
+		// display legacy Xerxes 1.x proxy URLs as direct URLs
+		if (strpos($xml->url, '&action=proxy'))
+		{
+			$xml->url = urldecode(substr(strstr($this->getURL(), '&url='), 5));
+		}
+		
 		return Parser::convertToDOMDocument($xml);
 	}
 }


### PR DESCRIPTION
This allows us to import old xerxes_records table and display the stored URLs.
